### PR TITLE
fix(gvisor): fix epoll use-after-free

### DIFF
--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -121,7 +121,8 @@ public:
 
     int32_t expand_buffer(size_t size);
 
-	scap_sized_buffer m_buf;
+    scap_sized_buffer m_buf;
+	bool m_closing;
 };
 
 class engine {


### PR DESCRIPTION
Signed-off-by: Lorenzo Susini <susinilorenzo1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

/area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-udig

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR attempts to fix a use-after-free bug in the gVisor engine. 
The bug is in the `next` function of the `scap_gvisor` class and specifically in the way we are handling `epoll_wait` return values and freeing sandbox entries. 
It is possible for `epoll_wait` to return both `EPOLLIN` and `EPOLLHUP`. In that case, this is the sequence of events that lead to the bug: 

1. we process the message by reading the fd 
2. we erase the sandbox entry from the map. This calls the sandbox entry destructor, deallocating the buffer used for this sandbox
3. we return a pointer pointing to the freed buffer
4. most probably, when we try to decode the event, we will read junk, also causing a segmentation fault

The fix marks the sandbox as to be closed and it frees the buffer when queue is empty, meaning that all those buffer are currently unused and holding no events.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
